### PR TITLE
build the links snap package with goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,3 +17,10 @@ release:
   draft: true
 snapshot:
   name_template: snapshot-{{.Commit}}
+snapcraft:
+  name: linksml
+  summary: URL Shortener
+  description: Simple, fast link shortener
+  apps:
+    links:
+      plugs: [network, network-bind, home]


### PR DESCRIPTION
This package will let you publish the latest links in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.